### PR TITLE
remove the checked properties

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
                         </label>
                     </figure>
                     <figure>
-                        <input type="radio" name="game-color" value="black" checked>
+                        <input type="radio" name="game-color" value="black">
                         <label for="black">
                             black
                         </label>
@@ -36,7 +36,7 @@
                 <fieldset class="binary-selector" name="mode">
                     <legend>What is flex or fail?</legend>
                     <figure>
-                    <input type="radio" name="game-type" value="flex" id="flex" checked>
+                    <input type="radio" name="game-type" value="flex" id="flex">
                     <label for="flex">
                         flex
                     </label>


### PR DESCRIPTION
remove the checked properties from game-type and game-color to make sure chat explicitly set them instead of just accepting the defaults. 